### PR TITLE
plugins configurable with values + decouple from dda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dispatcher
 *.gpg
 conf/conf_env.yml
 values-*.yaml
+conf/*
+!conf/*example*

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -4,32 +4,10 @@ metadata:
   name: dispatcher-config
   namespace: {{ .Values.environment }}
 data:
-  osa_data_server_conf.yml: |
+{{- range $plugin, $conf := .Values.plugins -}}
+  {{- if $conf.enabled }}
+  {{$plugin}}_data_server_conf.yml: |
     instruments:
-      isgri:
-          dispatcher_mnt_point: /data
-          data_server_cache: reduced/ddcache
-          dummy_cache: /data/dummy_prods
-          data_server_url: http://oda-dda-interface:8000
-
-      jemx:
-          dispatcher_mnt_point: /data
-          data_server_cache: reduced/ddcache
-          dummy_cache: /data/dummy_prods
-          data_server_url: http://oda-dda-interface:8000
-
-
-  magic_data_server_conf.yml: |
-    instruments:
-      magic:
-          data_server_url: http://oda-magic:8000
-  
-
-  polar_data_server_conf.yml: |
-    instruments:
-      polar:
-          dispatcher_mnt_point:
-          data_server_cache:
-          dummy_cache: dummy_prods
-          data_server_url: polar-worker
-          data_server_port: 8893
+      {{- toYaml $conf.instruments | nindent 6 }}
+  {{- end }}
+{{- end -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -4,10 +4,46 @@ metadata:
   name: dispatcher-config
   namespace: {{ .Values.environment }}
 data:
-{{- range $plugin, $conf := .Values.plugins -}}
-  {{- if $conf.enabled }}
-  {{$plugin}}_data_server_conf.yml: |
+  osa_data_server_conf.yml: |
     instruments:
-      {{- toYaml $conf.instruments | nindent 6 }}
-  {{- end }}
-{{- end -}}
+      isgri:
+        dispatcher_mnt_point: /data
+        data_server_cache: reduced/ddcache
+        dummy_cache: /data/dummy_prods
+        data_server_url: {{ .Values.isgri_data_server_url | default "http://oda-dda-interface:8000" }}
+
+      jemx:
+        dispatcher_mnt_point: /data
+        data_server_cache: reduced/ddcache
+        dummy_cache: /data/dummy_prods
+        data_server_url: {{ .Values.jemx_data_server_url | default "http://oda-dda-interface:8000" }}
+
+
+  magic_data_server_conf.yml: |
+    instruments:
+      magic:
+        data_server_url: {{ .Values.magic_data_server_url | default "http://oda-magic:8000" }}
+  
+
+  polar_data_server_conf.yml: |
+    instruments:
+      polar:
+        dispatcher_mnt_point:
+        data_server_cache:
+        dummy_cache: dummy_prods
+        data_server_url: {{ .Values.polar_data_server_url | default "polar-worker" }}
+        data_server_port: {{ .Values.polar_data_server_port | default 8893 }}
+
+  antares_data_server_conf.yml: |
+    instruments:
+      antares:
+        data_server_url: {{ .Values.antares_data_server_url | default "http://oda-antares:8000" }}
+        dummy_cache: dummy_prods 
+
+  spiacs_data_server_conf: |
+    instruments:
+      spi_acs:
+        dispatcher_mnt_point:
+        data_server_cache:
+        dummy_cache: dummy_prods
+        data_server_url: {{ .Values.spiacs_data_server_url | default "https://www.astro.unige.ch/cdci/astrooda/dispatch-data/gw/integralhk/api/v1.0/genlc/ACS/{t0_isot}/{dt_s}" }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,18 +53,20 @@ spec:
         hostPath:
           path: {{ .Values.oda.ddcache }}
       {{ else }}
-      - name: scratch
-        persistentVolumeClaim:
-          claimName: dda-interface-scratch
       - name: dispatcher-scratch-root
         persistentVolumeClaim:
           claimName: dispatcher-scratch-root
       - name: filelogdir
         persistentVolumeClaim:
-          claimName: dda-filelogdir
+          claimName: dispatcher-filelogdir
+      {{- if .Values.plugins.osa.enabled }}
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: dda-interface-scratch
       - name: data-reduced-ddcache
         persistentVolumeClaim:
           claimName: data-reduced-ddcache
+      {{- end }}
       #- name: isdc-arc-rev3
       #- name: isdc-pvphase-nrt-ops
       {{ end }}
@@ -122,14 +124,16 @@ spec:
             value: "no"
             {{- end }}
           volumeMounts:
-          - mountPath: /scratch
-            name: scratch
           - mountPath: /var/log/containers
             name: filelogdir
-          - mountPath: /data/reduced/ddcache
-            name: data-reduced-ddcache
           - mountPath: /data/dispatcher_scratch
             name: dispatcher-scratch-root
+          {{- if .Values.plugins.osa.enabled }}
+          - mountPath: /data/reduced/ddcache
+            name: data-reduced-ddcache
+          - mountPath: /scratch
+            name: scratch
+          {{- end }}
 
           - mountPath: /dispatcher/conf/conf_env.yml
             name: dispatcher-conf-secret

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       - name: filelogdir
         persistentVolumeClaim:
           claimName: dispatcher-filelogdir
-      {{- if .Values.plugins.osa.enabled }}
+      {{- if .Values.mount_dda }}
       - name: scratch
         persistentVolumeClaim:
           claimName: dda-interface-scratch
@@ -128,7 +128,7 @@ spec:
             name: filelogdir
           - mountPath: /data/dispatcher_scratch
             name: dispatcher-scratch-root
-          {{- if .Values.plugins.osa.enabled }}
+          {{- if .Values.mount_dda }}
           - mountPath: /data/reduced/ddcache
             name: data-reduced-ddcache
           - mountPath: /scratch
@@ -139,14 +139,11 @@ spec:
             name: dispatcher-conf-secret
             subPath: conf_env.yml
             readOnly: true
-
-          {{- range $plugin, $conf := .Values.plugins -}}
-            {{- if $conf.enabled }}
+          {{- range $plugin := list "osa" "magic" "polar" "antares" "spiacs" }}
           - name: dispatcher-config-volume
             mountPath: /dispatcher/conf/conf.d/{{$plugin}}_data_server_conf.yml
             subPath: {{$plugin}}_data_server_conf.yml
             readOnly: true
-            {{- end }}
           {{- end }}  
 
         - name: celery

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -135,18 +135,15 @@ spec:
             name: dispatcher-conf-secret
             subPath: conf_env.yml
             readOnly: true
+
+          {{- range $plugin, $conf := .Values.plugins -}}
+            {{- if $conf.enabled }}
           - name: dispatcher-config-volume
-            mountPath: /dispatcher/conf/conf.d/osa_data_server_conf.yml
-            subPath: osa_data_server_conf.yml
+            mountPath: /dispatcher/conf/conf.d/{{$plugin}}_data_server_conf.yml
+            subPath: {{$plugin}}_data_server_conf.yml
             readOnly: true
-          - name: dispatcher-config-volume
-            mountPath: /dispatcher/conf/conf.d/polar_data_server_conf.yml
-            subPath: polar_data_server_conf.yml
-            readOnly: true
-          - name: dispatcher-config-volume
-            mountPath: /dispatcher/conf/conf.d/magic_data_server_conf.yml
-            subPath: magic_data_server_conf.yml
-            readOnly: true
+            {{- end }}
+          {{- end }}  
 
         - name: celery
           securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -101,55 +101,8 @@ tolerations: []
 affinity: {}
 
 oda:
-  use_hostpath: true
   ddaQueue: queue-osa11
   ddcache: "/net/cdcicn02/scratch/shared/savchenk/data/reduced/ddcache"
-
-plugins:
-  osa:
-    ebabled: true
-    instruments:
-      isgri:
-        dispatcher_mnt_point: /data
-        data_server_cache: reduced/ddcache
-        dummy_cache: /data/dummy_prods
-        data_server_url: http://oda-dda-interface:8000
-
-      jemx:
-        dispatcher_mnt_point: /data
-        data_server_cache: reduced/ddcache
-        dummy_cache: /data/dummy_prods
-        data_server_url: http://oda-dda-interface:8000
-
-  magic:
-    enabled: true
-    instruments:
-      magic:
-        data_server_url: http://oda-magic:8000
-        dummy_cache: /data/dummy_prods
-
-  polar:
-    enabled: true
-    instruments:
-      polar:
-        dispatcher_mnt_point:
-        data_server_cache:
-        dummy_cache: /data/dummy_prods
-        data_server_url: polar-worker
-        data_server_port: 8893
-
-  antares:
-    enabled: true
-    instruments:
-      antares:
-        data_server_url: http://oda-antares:8000
-        dummy_cache: /data/dummy_prods
-
-  spiacs:
-    enabled: true
-    instruments:
-      spi_acs:
-        dispatcher_mnt_point:
-        data_server_cache:
-        dummy_cache: /data/dummy_prods
-        data_server_url: https://www.astro.unige.ch/cdci/astrooda/dispatch-data/gw/integralhk/api/v1.0/genlc/ACS/{t0_isot}/{dt_s}
+use_hostpath: true
+mount_dda: true # mount dda-related volumes into dispatcher
+                # MUST be false if installing dispatcher without dda backend

--- a/values.yaml
+++ b/values.yaml
@@ -104,3 +104,52 @@ oda:
   use_hostpath: true
   ddaQueue: queue-osa11
   ddcache: "/net/cdcicn02/scratch/shared/savchenk/data/reduced/ddcache"
+
+plugins:
+  osa:
+    ebabled: true
+    instruments:
+      isgri:
+        dispatcher_mnt_point: /data
+        data_server_cache: reduced/ddcache
+        dummy_cache: /data/dummy_prods
+        data_server_url: http://oda-dda-interface:8000
+
+      jemx:
+        dispatcher_mnt_point: /data
+        data_server_cache: reduced/ddcache
+        dummy_cache: /data/dummy_prods
+        data_server_url: http://oda-dda-interface:8000
+
+  magic:
+    enabled: true
+    instruments:
+      magic:
+        data_server_url: http://oda-magic:8000
+        dummy_cache: /data/dummy_prods
+
+  polar:
+    enabled: true
+    instruments:
+      polar:
+        dispatcher_mnt_point:
+        data_server_cache:
+        dummy_cache: /data/dummy_prods
+        data_server_url: polar-worker
+        data_server_port: 8893
+
+  antares:
+    enabled: true
+    instruments:
+      antares:
+        data_server_url: http://oda-antares:8000
+        dummy_cache: /data/dummy_prods
+
+  spiacs:
+    enabled: true
+    instruments:
+      spi_acs:
+        dispatcher_mnt_point:
+        data_server_cache:
+        dummy_cache: /data/dummy_prods
+        data_server_url: https://www.astro.unige.ch/cdci/astrooda/dispatch-data/gw/integralhk/api/v1.0/genlc/ACS/{t0_isot}/{dt_s}


### PR DESCRIPTION
1. data_server_conf files were hardcoded in configmap.yaml, which is not good for configuration files.

2. Added configs for Antares and spi_acs

3. Besides previous tweaks of pvc.yaml it was still not possible to deploy dispatcher without dda. 
Fixed this, but please inspect carefully, @volodymyrss 